### PR TITLE
Refactor: Decouple Reddit login from data synchronization

### DIFF
--- a/src/SfR/Actions.hs
+++ b/src/SfR/Actions.hs
@@ -77,7 +77,7 @@ callback = do
                                    userSessionKey user ++
                                    "; HttpOnly; Path=/; MaxAge=3600" ++
                                    if secure_cookie then "; Secure" else ""))
-  redirect "/sync"
+  redirect "/view"
 
 -- | Sync action (refreshes saved items from [Reddit](https://www.reddit.com)).
 --


### PR DESCRIPTION
I modified the OAuth callback action to redirect to the main view page ('/view') instead of automatically triggering a data sync ('/sync').

This change allows you to log in without an immediate data pull. Data synchronization can now be manually initiated by you via the existing "Refresh" link in the main menu, which is available on the '/view' page.

No changes were needed to the view template itself, as the "Refresh" functionality was already present.